### PR TITLE
Add standard-xdrlib run dependency for python >=3.13 support

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -7,4 +7,4 @@ channel_targets:
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 python_min:
-- '3.9'
+- '3.10'

--- a/pixi.toml
+++ b/pixi.toml
@@ -7,7 +7,7 @@
 
 [project]
 name = "python-vxi11-feedstock"
-version = "3.51.1"  # conda-smithy version used to generate this file
+version = "3.52.1"  # conda-smithy version used to generate this file
 description = "Pixi configuration for conda-forge/python-vxi11-feedstock"
 authors = ["@conda-forge/python-vxi11"]
 channels = ["conda-forge"]
@@ -34,6 +34,7 @@ description = "List contents of python-vxi11-feedstock packages built for varian
 
 [feature.smithy.dependencies]
 conda-smithy = "*"
+shellcheck = "*"
 [feature.smithy.tasks.build-locally]
 cmd = "python ./build-locally.py"
 description = "Build packages locally using the same setup scripts used in conda-forge's CI"

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -13,7 +13,7 @@ source:
   sha256: 01fbd8d5be09352c6be46ae474a47d4fe44be2989f7e977c578c55733b076dff
 
 build:
-  number: 2
+  number: 3
   noarch: python
   script: ${{ PYTHON }} -m pip install . -vv
   python:
@@ -26,14 +26,17 @@ requirements:
     - pip
     - setuptools
   run:
-    - python >=${{ python_min }},<3.13
+    - python >=${{ python_min }}
+    - standard-xdrlib
     - __unix
 
 tests:
   - python:
       imports:
         - vxi11
-      python_version: ["${{ python_min }}.*", "3.*"]
+      python_version:
+        - ${{ python_min }}.*
+        - 3.*
       pip_check: true
   - script:
       - vxi11-cli --help


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
xdrlib was removed from python 3.13.
xtandard-xdrlib provides it for python >=3.13 (package is empty for lower versions).
